### PR TITLE
Enable ESM and add framework scaffolds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ArcaneGames
 
-ArcaneGames is a lightweight TypeScript framework for building text-based RPGs.
+ArcaneGames is a lightweight **ESM-first** TypeScript framework for building text-based RPGs.
 It provides utilities for managing game state, timers, an event system and a
-simple command architecture.
+simple command architecture. New modules lay the groundwork for plugins, a story engine and multiplayer support.
 
 ## Installation
 
@@ -27,7 +27,7 @@ npm run lint
 ## Usage Example
 
 ```ts
-import { ArcaneMemory } from './dist/libs/ArcaneMemory';
+import { ArcaneMemory } from './dist/libs/ArcaneMemory.js';
 
 const memory = new ArcaneMemory();
 memory.set('location', 'Avalon');
@@ -37,7 +37,7 @@ console.log(memory.get('location')); // -> 'Avalon'
 Commands can be registered and executed using `CommandRegistry`:
 
 ```ts
-import { CommandRegistry } from './dist/commands/CommandRegistry';
+import { CommandRegistry } from './dist/commands/CommandRegistry.js';
 
 const registry = new CommandRegistry();
 await registry.loadCommands('./dist/commands');

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
-- Plugin Architecture: Designing a way for others to extend your framework with custom modules or plugins.
-- Dynamic Story Engine: Implementing a more complex narrative engine that can adapt to player choices in real-time.
-- Multiplayer Support: support for multiple players in the same world, websockets for chat?.
+- Plugin Architecture: Basic `Plugin` interface and manager implemented.
+- Dynamic Story Engine: Initial `StoryEngine` class added.
+- Multiplayer Support: WebSocket server scaffold provided.
 - State Serialization: Allowing the game state to be saved and loaded, so players can pick up where they left off.
 - Interactive UI: Creating a more interactive user interface, maybe an abtract interfact that allows basid rendering and text input like an old MUD.
 - AI NPCs: Need to create NPCs with dynamic behaviors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,13 @@
       "name": "arcanegames",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.3"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.4",
+        "@types/node": "^24.0.13",
         "@typescript-eslint/eslint-plugin": "^6.6.0",
         "@typescript-eslint/parser": "^6.6.0",
         "eslint": "^8.48.0",
@@ -1341,13 +1346,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
-      "dev": true,
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
+      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/semver": {
@@ -1363,6 +1367,15 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -5111,10 +5124,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -5246,6 +5258,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arcanegames",
   "version": "1.0.0",
   "description": "A Robust Framework for Weaving Intricate Text-Based Adventures.",
-  "type": "commonjs",
+  "type": "module",
   "main": "dist/main.js",
   "exports": "./dist/main.js",
   "types": "dist/main.d.ts",
@@ -23,6 +23,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^29.5.4",
+    "@types/node": "^24.0.13",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "@typescript-eslint/parser": "^6.6.0",
     "eslint": "^8.48.0",
@@ -35,5 +36,9 @@
   },
   "files": [
     "dist/"
-  ]
+  ],
+  "dependencies": {
+    "@types/ws": "^8.18.1",
+    "ws": "^8.18.3"
+  }
 }

--- a/src/libs/ArcaneMemory.ts
+++ b/src/libs/ArcaneMemory.ts
@@ -337,6 +337,27 @@ export class ArcaneMemory {
   }
 
   /**
+   * Retrieves multiple keys from the store.
+   * @param keys - An array of keys to retrieve.
+   * @param updateTimers - [Optional] If true, associated timers will be updated. (Defaults to true)
+   * @returns An object containing the found key-value pairs.
+   */
+  getMultiple(keys: string[], updateTimers = true): Record<string, unknown> {
+    const data: Record<string, unknown> = {};
+    for (const key of keys) {
+      const value = this.store.get(key);
+      if (value !== undefined) {
+        const timer = this.timers.get(key);
+        if (timer && updateTimers) {
+          timer.get();
+        }
+        data[key] = value;
+      }
+    }
+    return data;
+  }
+
+  /**
    * Select keys based on a filter function.
    * @param filter - The filter function to use.
    * @param updateTimers - [Optional] If true, the associated timers will be updated. (Defaults to true)

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,3 +2,7 @@ export * from './libs/ArcaneMemory';
 export * from './libs/ChronoWarden';
 export * from './libs/EventAlchemist';
 export * from './commands';
+export * from './plugins/Plugin';
+export * from './plugins/PluginManager';
+export * from './story/StoryEngine';
+export * from './multiplayer/MultiplayerServer';

--- a/src/multiplayer/MultiplayerServer.ts
+++ b/src/multiplayer/MultiplayerServer.ts
@@ -1,0 +1,26 @@
+import { WebSocketServer, WebSocket } from 'ws';
+
+export class MultiplayerServer {
+  private wss: WebSocketServer;
+
+  constructor(port = 8080) {
+    this.wss = new WebSocketServer({ port });
+    this.wss.on('connection', ws => {
+      ws.on('message', data => {
+        this.broadcast(data.toString(), ws);
+      });
+    });
+  }
+
+  broadcast(message: string, sender?: WebSocket): void {
+    for (const client of this.wss.clients) {
+      if (client !== sender && client.readyState === WebSocket.OPEN) {
+        client.send(message);
+      }
+    }
+  }
+
+  close(): void {
+    this.wss.close();
+  }
+}

--- a/src/plugins/Plugin.ts
+++ b/src/plugins/Plugin.ts
@@ -1,0 +1,8 @@
+import { CommandRegistry } from '../commands/CommandRegistry';
+import { StoryEngine } from '../story/StoryEngine';
+
+export interface Plugin {
+  name: string;
+  init?(engine: StoryEngine): Promise<void> | void;
+  register?(registry: CommandRegistry): Promise<void> | void;
+}

--- a/src/plugins/PluginManager.ts
+++ b/src/plugins/PluginManager.ts
@@ -1,0 +1,37 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { Plugin } from './Plugin';
+import { StoryEngine } from '../story/StoryEngine';
+import { CommandRegistry } from '../commands/CommandRegistry';
+
+export class PluginManager {
+  private plugins: Map<string, Plugin> = new Map();
+
+  async loadPlugins(dir: string): Promise<void> {
+    const files = await fs.readdir(dir);
+    for (const file of files) {
+      if (!file.endsWith('.js') && !file.endsWith('.ts')) continue;
+      const mod = await import(path.join(dir, file));
+      const PluginClass = mod.default || mod.Plugin;
+      if (typeof PluginClass === 'function') {
+        const plugin: Plugin = new PluginClass();
+        this.plugins.set(plugin.name, plugin);
+      }
+    }
+  }
+
+  async init(engine: StoryEngine, registry: CommandRegistry): Promise<void> {
+    for (const plugin of this.plugins.values()) {
+      if (plugin.init) await plugin.init(engine);
+      if (plugin.register) await plugin.register(registry);
+    }
+  }
+
+  get(name: string): Plugin | undefined {
+    return this.plugins.get(name);
+  }
+
+  list(): Plugin[] {
+    return Array.from(this.plugins.values());
+  }
+}

--- a/src/story/StoryEngine.ts
+++ b/src/story/StoryEngine.ts
@@ -1,0 +1,51 @@
+import { ArcaneMemory } from '../libs/ArcaneMemory';
+
+export interface Choice {
+  text: string;
+  next: string;
+}
+
+export interface Scene {
+  id: string;
+  text: string;
+  choices: Choice[];
+}
+
+export class StoryEngine {
+  private memory: ArcaneMemory;
+  private scenes = new Map<string, Scene>();
+  private current?: string;
+
+  constructor(memory: ArcaneMemory = new ArcaneMemory()) {
+    this.memory = memory;
+  }
+
+  addScene(scene: Scene): void {
+    this.scenes.set(scene.id, scene);
+  }
+
+  start(id: string): Scene | undefined {
+    this.current = id;
+    return this.scenes.get(id);
+  }
+
+  choose(index: number): Scene | undefined {
+    if (!this.current) return undefined;
+    const scene = this.scenes.get(this.current);
+    if (!scene) return undefined;
+    const choice = scene.choices[index];
+    if (!choice) return undefined;
+    this.current = choice.next;
+    return this.scenes.get(choice.next);
+  }
+
+  serialize(): string {
+    return JSON.stringify({ scene: this.current, memory: this.memory.serialize() });
+  }
+
+  deserialize(json: string): void {
+    const data = JSON.parse(json);
+    this.current = data.scene;
+    this.memory.deserialize(data.memory);
+  }
+}

--- a/tests/ArcaneMemory.spec.ts
+++ b/tests/ArcaneMemory.spec.ts
@@ -242,3 +242,24 @@ describe("ArcaneMemory - selectEntriesByContext", () => {
     });
    
 });
+
+describe("ArcaneMemory - getMultiple", () => {
+    const store = new ArcaneMemory();
+
+    beforeEach(() => {
+        store.clear();
+    });
+
+    it("should retrieve multiple existing keys", () => {
+        store.set('a', 1);
+        store.set('b', 2);
+        const data = store.getMultiple(['a', 'b']);
+        expect(data).toEqual({ a: 1, b: 2 });
+    });
+
+    it("should ignore keys that do not exist", () => {
+        store.set('a', 1);
+        const data = store.getMultiple(['a', 'c']);
+        expect(data).toEqual({ a: 1 });
+    });
+})

--- a/tests/EventAlchemist.spec.ts
+++ b/tests/EventAlchemist.spec.ts
@@ -6,7 +6,7 @@ interface TestClass extends Eventful { }
 
 @EventAlchemy("test")
 class TestClass {
-  @EventElixer("test", function (result, ...args) { console.log('Default: ', result, args); return result }, "test event")
+  @EventElixer("test", (result) => result, "test event")
   testEvent(numA: number, numB: number) {
     return numA + numB;
   }

--- a/tests/StoryEngine.spec.ts
+++ b/tests/StoryEngine.spec.ts
@@ -1,0 +1,14 @@
+import { StoryEngine, Scene } from '../src/story/StoryEngine';
+
+describe('StoryEngine', () => {
+  it('should advance between scenes', () => {
+    const engine = new StoryEngine();
+    const a: Scene = { id: 'a', text: 'A', choices: [{ text: 'toB', next: 'b' }] };
+    const b: Scene = { id: 'b', text: 'B', choices: [] };
+    engine.addScene(a);
+    engine.addScene(b);
+
+    expect(engine.start('a')).toEqual(a);
+    expect(engine.choose(0)).toEqual(b);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "exclude": ["node_modules"],
   "compilerOptions": {
     "target": "ESNext",
-    "module": "commonjs",
+    "module": "esnext",
+    "moduleResolution": "node",
     "outDir": "./dist",
     "rootDir": "./src",
     "baseUrl": "./src",
@@ -15,6 +16,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "declaration": true,
+    "types": ["node"],
     "paths": {
       "@core/*": ["core/*"],
       "@utils/*": ["utils/*"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "include": ["./tests/**/*.ts"],
     "compilerOptions": {
-      "types": ["jest"]
+      "types": ["jest", "node"],
+      "module": "esnext"
     }
 }


### PR DESCRIPTION
## Summary
- switch repository to ESM modules
- add Node types for compilation
- remove console log from EventAlchemist test
- implement `getMultiple` in `ArcaneMemory`
- scaffold plugin architecture, story engine, and multiplayer server
- add basic tests for new story engine

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68755fdd7e78832684842a50c63f12b5