### PR TITLE
Remove orphan getMultiple reference

### DIFF
--- a/src/libs/ArcaneMemory.ts
+++ b/src/libs/ArcaneMemory.ts
@@ -322,7 +322,6 @@ export class ArcaneMemory {
    * @see {@link ArcaneMemory#getSelectedKeys}
    * @see {@link ArcaneMemory#getAllKeys}
    * @see {@link ArcaneMemory#getAllValues}
-   * @see {@link ArcaneMemory#getMultiple}
    */
   getAllEntries(updateTimers = false): Record<string, unknown> {
     const allEntries: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- clean up documentation for `ArcaneMemory#getAllEntries`
- remove reference to unimplemented `getMultiple`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68756125eeb88326a431bdc9620f843e